### PR TITLE
introducing mimic so that we can mimic calls to OAuth2; adding a miss…

### DIFF
--- a/lib/ueberauth/strategy/auth0.ex
+++ b/lib/ueberauth/strategy/auth0.ex
@@ -152,8 +152,11 @@ defmodule Ueberauth.Strategy.Auth0 do
           |> verify_token_and_put_private(client)
         end
 
-      {:error, client} ->
-        set_errors!(conn, [error(client.body["error"], client.body["error_description"])])
+      {:error, %{body: %{"error" => error, "error_description" => error_description}}} ->
+        set_errors!(conn, [error(error, error_description)])
+
+      {:error, error} ->
+        set_errors!(conn, [error(error, "")])
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -54,6 +54,7 @@ defmodule UeberauthAuth0.Mixfile do
       # Testing:
       {:exvcr, "~> 0.10", only: :test},
       {:excoveralls, "~> 0.11", only: :test},
+      {:mimic, "~> 1.7", only: :test},
 
       # Type checking
       {:dialyxir, "~> 1.2.0", only: [:dev, :test], runtime: false},

--- a/mix.lock
+++ b/mix.lock
@@ -25,6 +25,7 @@
   "metrics": {:hex, :metrics, "1.0.1", "25f094dea2cda98213cecc3aeff09e940299d950904393b2a29d191c346a8486", [:rebar3], [], "hexpm", "69b09adddc4f74a40716ae54d140f93beb0fb8978d8636eaded0c31b6f099f16"},
   "mime": {:hex, :mime, "2.0.3", "3676436d3d1f7b81b5a2d2bd8405f412c677558c81b1c92be58c00562bb59095", [:mix], [], "hexpm", "27a30bf0db44d25eecba73755acf4068cbfe26a4372f9eb3e4ea3a45956bff6b"},
   "mimerl": {:hex, :mimerl, "1.2.0", "67e2d3f571088d5cfd3e550c383094b47159f3eee8ffa08e64106cdf5e981be3", [:rebar3], [], "hexpm", "f278585650aa581986264638ebf698f8bb19df297f66ad91b18910dfc6e19323"},
+  "mimic": {:hex, :mimic, "1.7.4", "cd2772ffbc9edefe964bc668bfd4059487fa639a5b7f1cbdf4fd22946505aa4f", [:mix], [], "hexpm", "437c61041ecf8a7fae35763ce89859e4973bb0666e6ce76d75efc789204447c3"},
   "mix_test_watch": {:hex, :mix_test_watch, "1.1.0", "330bb91c8ed271fe408c42d07e0773340a7938d8a0d281d57a14243eae9dc8c3", [:mix], [{:file_system, "~> 0.2.1 or ~> 0.3", [hex: :file_system, repo: "hexpm", optional: false]}], "hexpm", "52b6b1c476cbb70fd899ca5394506482f12e5f6b0d6acff9df95c7f1e0812ec3"},
   "nimble_parsec": {:hex, :nimble_parsec, "1.2.3", "244836e6e3f1200c7f30cb56733fd808744eca61fd182f731eac4af635cc6d0b", [:mix], [], "hexpm", "c8d789e39b9131acf7b99291e93dae60ab48ef14a7ee9d58c6964f59efb570b0"},
   "oauth2": {:hex, :oauth2, "2.0.1", "70729503e05378697b958919bb2d65b002ba6b28c8112328063648a9348aaa3f", [:mix], [{:hackney, "~> 1.13", [hex: :hackney, repo: "hexpm", optional: false]}], "hexpm", "c64e20d4d105bcdbcbe03170fb530d0eddc3a3e6b135a87528a22c8aecf74c52"},

--- a/test/test_helper.exs
+++ b/test/test_helper.exs
@@ -33,4 +33,6 @@ defmodule SpecSignerModule do
   end
 end
 
+Mimic.copy(Ueberauth.Strategy.Auth0.OAuth)
+
 ExUnit.start()


### PR DESCRIPTION
…ing test for when OAuth2 calls return string errors & fixing it.

https://app.datadoghq.eu/logs?query=service%3Aauthentication_service%20status%3Aerror%20env%3Aproduction%20&agg_m=count&agg_t=count&cols=host%2Cservice&event=AgAAAY6kfDtfLd3sfAAAAAAAAAAYAAAAAEFZNmtmRHdQQUFCdW9MdFlMM2VyQndBRgAAACQAAAAAMDE4ZWE0ODktN2UzMS00NTk2LTgwNDUtMThkNTA5ODIxMjJj&fromUser=true&index=%2A&messageDisplay=inline&refresh_mode=sliding&source=monitor_notif&storage=hot&stream_sort=desc&viz=stream&from_ts=1712156545000&to_ts=1712156605000&live=false

see above link, this PR stops crashing in these instances